### PR TITLE
Proposta de implementação do lucid_validation e result_dart

### DIFF
--- a/design_system/lib/src/inputs/text_input_ds.dart
+++ b/design_system/lib/src/inputs/text_input_ds.dart
@@ -4,23 +4,25 @@ import '../../design_system.dart';
 
 class TextInputDs extends StatefulWidget {
   final String label;
-  final TextEditingController controller;
+  final TextEditingController? controller;
   final Function(String)? validator;
   final double height;
   final double width;
   final bool isFilled;
   final bool isPassword;
   final TextInputType textInputType;
+  final ValueChanged<String>? onChanged;
 
   const TextInputDs({
     super.key,
     required this.label,
-    required this.controller,
+    this.controller,
     this.validator,
     this.height = 50,
     this.width = 303,
     this.isFilled = true,
     this.isPassword = false,
+    this.onChanged,
     this.textInputType = TextInputType.text,
   });
 
@@ -50,6 +52,7 @@ class _TextInputDsState extends State<TextInputDs> {
           keyboardType: widget.textInputType,
           obscureText: _isObscure,
           controller: widget.controller,
+          onChanged: widget.onChanged,
           decoration: InputDecoration(
             suffixIcon: widget.isPassword
                 ? IconButton(

--- a/design_system/lib/src/inputs/text_input_ds.dart
+++ b/design_system/lib/src/inputs/text_input_ds.dart
@@ -5,13 +5,14 @@ import '../../design_system.dart';
 class TextInputDs extends StatefulWidget {
   final String label;
   final TextEditingController? controller;
-  final Function(String)? validator;
+  final String? Function(String?)? validator;
   final double height;
   final double width;
   final bool isFilled;
   final bool isPassword;
   final TextInputType textInputType;
   final ValueChanged<String>? onChanged;
+  final AutovalidateMode? autovalidateMode;
 
   const TextInputDs({
     super.key,
@@ -23,6 +24,7 @@ class TextInputDs extends StatefulWidget {
     this.isFilled = true,
     this.isPassword = false,
     this.onChanged,
+    this.autovalidateMode,
     this.textInputType = TextInputType.text,
   });
 
@@ -49,9 +51,11 @@ class _TextInputDsState extends State<TextInputDs> {
         borderRadius: BorderRadius.circular(5),
         elevation: 3,
         child: TextFormField(
+          autovalidateMode: widget.autovalidateMode,
           keyboardType: widget.textInputType,
           obscureText: _isObscure,
           controller: widget.controller,
+          validator: widget.validator,
           onChanged: widget.onChanged,
           decoration: InputDecoration(
             suffixIcon: widget.isPassword

--- a/lib/core/cache/cache_params.dart
+++ b/lib/core/cache/cache_params.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:lucid_validation/lucid_validation.dart';
 
 import 'src/app_widget.dart';
 import 'src/core/DI/dependency_injector.dart';
@@ -7,6 +8,8 @@ import 'src/core/DI/dependency_injector.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
+  final culture = Culture('pt', 'BR');
+  LucidValidation.global.culture = culture;
   setupDependencyInjector();
   runApp(const AppWidget());
 }

--- a/lib/src/app/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/src/app/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
 
-import 'package:fpdart/fpdart.dart';
+import 'package:result_dart/result_dart.dart';
 
 import '../../../../../core/client_http/app_response.dart';
 import '../../../../../core/client_http/client_http.dart';
@@ -46,25 +46,25 @@ class AuthRepositoryImpl implements IAuthRepository {
           (dynamic json) => AuthModel.fromMap(json as Map<String, dynamic>),
         );
 
-        return right(appResponse);
+        return Success(appResponse);
       }
 
       if (response.statusCode == 401) {
-        return left(
+        return Failure(
           UnauthorizedException(
             message: response.data['message'],
           ),
         );
       }
 
-      return left(
+      return Failure(
         ServerException(
           message: 'Error',
           error: response.data['message'],
         ),
       );
     } catch (e) {
-      return left(
+      return Failure(
         ServerException(
           message: 'Error',
           error: e.toString(),
@@ -107,17 +107,17 @@ class AuthRepositoryImpl implements IAuthRepository {
           (dynamic json) => UserModel.fromMap(json as Map<String, dynamic>),
         );
 
-        return right(appResponse);
+        return Success(appResponse);
       }
 
-      return left(
+      return Failure(
         ServerException(
           message: 'Error',
           error: response.data['message'],
         ),
       );
     } catch (e) {
-      return left(
+      return Failure(
         ServerException(
           message: 'Error',
           error: e.toString(),

--- a/lib/src/app/features/auth/domain/dtos/login_params.dart
+++ b/lib/src/app/features/auth/domain/dtos/login_params.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/cupertino.dart';
+
+class LoginParams extends ChangeNotifier {
+  String email;
+  String password;
+
+  LoginParams({required this.email, required this.password});
+
+  factory LoginParams.empty() => LoginParams(
+        email: '',
+        password: '',
+      );
+
+  setEmail(String value) {
+    email = value;
+    notifyListeners();
+  }
+
+  setPassword(String value) {
+    password = value;
+    notifyListeners();
+  }
+}

--- a/lib/src/app/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/src/app/features/auth/domain/usecases/login_usecase.dart
@@ -1,6 +1,7 @@
 import '../../../../../core/client_http/app_response.dart';
 import '../../../../../core/typedefs/types.dart';
 import '../../../../../core/usecase/usecase_interface.dart';
+import '../dtos/login_params.dart';
 import '../entities/auth_entity.dart';
 import '../repositories/auth_repository_interface.dart';
 
@@ -15,11 +16,4 @@ class LoginUsecase implements UseCase<AppResponse<AuthEntity>, LoginParams> {
   Future<Output<AppResponse<AuthEntity>>> call(LoginParams params) async {
     return _authRepository.login(params.email, params.password);
   }
-}
-
-class LoginParams {
-  final String email;
-  final String password;
-
-  LoginParams({required this.email, required this.password});
 }

--- a/lib/src/app/features/auth/domain/validators/login_params_validator.dart
+++ b/lib/src/app/features/auth/domain/validators/login_params_validator.dart
@@ -1,0 +1,19 @@
+import 'package:lucid_validation/lucid_validation.dart';
+
+import '../dtos/login_params.dart';
+
+class LoginParamsValidator extends LucidValidator<LoginParams> {
+  LoginParamsValidator() {
+    ruleFor((user) => user.email, key: 'email')
+        .notEmpty()
+        .validEmail();
+
+    ruleFor((user) => user.password, key: 'password') //
+        .notEmpty()
+        .minLength(8, message: 'Must be at least 8 characters long')
+        .mustHaveLowercase()
+        .mustHaveUppercase()
+        .mustHaveNumber()
+        .mustHaveSpecialCharacter();
+  }
+}

--- a/lib/src/app/features/auth/domain/validators/login_params_validator.dart
+++ b/lib/src/app/features/auth/domain/validators/login_params_validator.dart
@@ -4,13 +4,13 @@ import '../dtos/login_params.dart';
 
 class LoginParamsValidator extends LucidValidator<LoginParams> {
   LoginParamsValidator() {
-    ruleFor((user) => user.email, key: 'email')
+    ruleFor((user) => user.email, key: 'email', label: 'e-mail')
         .notEmpty()
         .validEmail();
 
-    ruleFor((user) => user.password, key: 'password') //
+    ruleFor((user) => user.password, key: 'password', label: 'senha') //
         .notEmpty()
-        .minLength(8, message: 'Must be at least 8 characters long')
+        .minLength(8)
         .mustHaveLowercase()
         .mustHaveUppercase()
         .mustHaveNumber()

--- a/lib/src/app/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/src/app/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,11 +1,16 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:result_dart/result_dart.dart';
 
 import '../../../../../core/client_http/app_response.dart';
+import '../../../../../core/errors/base_exception.dart';
+import '../../../../../core/extensions/lucid_validator_extensions.dart';
+import '../../domain/dtos/login_params.dart';
 import '../../domain/entities/auth_entity.dart';
 import '../../domain/entities/user_entity.dart';
 import '../../domain/usecases/login_usecase.dart';
 import '../../domain/usecases/sign_up_usecase.dart';
+import '../../domain/validators/login_params_validator.dart';
 
 part 'auth_event.dart';
 part 'auth_state.dart';
@@ -34,23 +39,22 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       ));
 
       result.fold(
-        (error) => emit(SignUpAuthFailure(message: error.toString())),
         (success) => emit(SignUpAuthSuccess(data: success)),
+        (error) => emit(SignUpAuthFailure(message: error.toString())),
       );
     });
 
     on<LoginAuthEvent>((event, emit) async {
       emit(LoginAuthLoading());
+      final validator = LoginParamsValidator();
 
-      final result = await _loginUsecase.call(LoginParams(
-        email: event.email,
-        password: event.password,
-      ));
+      final newState = await validator
+          .validateResult(event.loginParams)                  /// valida o loginParams
+          .toAsyncResult()                                    /// converte em um async Result: Future<Result<...>>
+          .flatMap(_loginUsecase.call)                         /// executa o usecase
+          .fold(LoginAuthSuccess.new, LoginAuthFailure.new);  /// converte para o estado apropriado
 
-      result.fold(
-        (error) => emit(LoginAuthFailure(message: error.message)),
-        (success) => emit(LoginAuthSuccess(data: success)),
-      );
+      emit(newState);
     });
   }
 }

--- a/lib/src/app/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/src/app/features/auth/presentation/bloc/auth_event.dart
@@ -34,14 +34,12 @@ class SignUpAuthEvent extends AuthEvent {
 }
 
 class LoginAuthEvent extends AuthEvent {
-  final String email;
-  final String password;
+  final LoginParams loginParams;
 
   const LoginAuthEvent({
-    required this.email,
-    required this.password,
+    required this.loginParams,
   });
 
   @override
-  List<Object> get props => [email, password];
+  List<Object> get props => [loginParams];
 }

--- a/lib/src/app/features/auth/presentation/bloc/auth_state.dart
+++ b/lib/src/app/features/auth/presentation/bloc/auth_state.dart
@@ -38,21 +38,19 @@ class LoginAuthLoading extends AuthState {}
 class LoginAuthSuccess extends AuthState {
   final AppResponse<AuthEntity> data;
 
-  const LoginAuthSuccess({
-    required this.data,
-  });
+  const LoginAuthSuccess(this.data);
 
   @override
   List<Object> get props => [data];
 }
 
 class LoginAuthFailure extends AuthState {
-  final String message;
+  final BaseException exception;
 
-  const LoginAuthFailure({
-    required this.message,
-  });
+  const LoginAuthFailure(this.exception);
+
+  String get message => exception.message;
 
   @override
-  List<Object> get props => [message];
+  List<Object> get props => [exception];
 }

--- a/lib/src/app/features/auth/presentation/pages/login_page.dart
+++ b/lib/src/app/features/auth/presentation/pages/login_page.dart
@@ -9,6 +9,8 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../core/utils/show_snack_bar.dart';
+import '../../domain/dtos/login_params.dart';
+import '../../domain/validators/login_params_validator.dart';
 import '../bloc/auth_bloc.dart';
 import '../controller/session_controller.dart';
 
@@ -20,9 +22,11 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
+  final _loginParams = LoginParams.empty();
+  final _validator = LoginParamsValidator();
+
   final formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
     // final size = MediaQuery.sizeOf(context);
@@ -54,23 +58,15 @@ class _LoginPageState extends State<LoginPage> {
                 const Gap(50),
                 TextInputDs(
                   label: 'e-mail',
-                  controller: _emailController,
-                  validator: (p0) {
-                    if (p0.isEmpty) {
-                      return 'Campo Obrigatório';
-                    }
-                    if (!p0.contains('@')) {
-                      return 'E-mail inválido';
-                    }
-                    return null;
-                  },
+                  onChanged: _loginParams.setEmail,
+                  validator: _validator.byField(_loginParams, 'email'),
                 ),
                 const Gap(20),
                 TextInputDs(
                   label: 'senha',
-                  controller: _passwordController,
                   isPassword: true,
-                  validator: (p0) => p0.isEmpty ? 'Campo Obrigatório' : null,
+                  onChanged: _loginParams.setPassword,
+                  validator: _validator.byField(_loginParams, 'password'),
                 ),
                 const Gap(25),
                 BlocConsumer<AuthBloc, AuthState>(
@@ -106,10 +102,7 @@ class _LoginPageState extends State<LoginPage> {
                       onPressed: () {
                         if (formKey.currentState!.validate()) {
                           authBloc.add(
-                            LoginAuthEvent(
-                              email: _emailController.text,
-                              password: _passwordController.text,
-                            ),
+                            LoginAuthEvent(loginParams: _loginParams),
                           );
                         }
                       },

--- a/lib/src/app/features/auth/presentation/pages/login_page.dart
+++ b/lib/src/app/features/auth/presentation/pages/login_page.dart
@@ -60,6 +60,7 @@ class _LoginPageState extends State<LoginPage> {
                   label: 'e-mail',
                   onChanged: _loginParams.setEmail,
                   validator: _validator.byField(_loginParams, 'email'),
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                 ),
                 const Gap(20),
                 TextInputDs(
@@ -67,6 +68,7 @@ class _LoginPageState extends State<LoginPage> {
                   isPassword: true,
                   onChanged: _loginParams.setPassword,
                   validator: _validator.byField(_loginParams, 'password'),
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                 ),
                 const Gap(25),
                 BlocConsumer<AuthBloc, AuthState>(

--- a/lib/src/core/errors/credentials_validation_exception.dart
+++ b/lib/src/core/errors/credentials_validation_exception.dart
@@ -1,0 +1,5 @@
+import 'base_exception.dart';
+
+class CredentialsValidationException extends BaseException {
+  CredentialsValidationException({required super.message});
+}

--- a/lib/src/core/errors/errors.dart
+++ b/lib/src/core/errors/errors.dart
@@ -1,4 +1,5 @@
 export 'base_exception.dart';
+export 'credentials_validation_exception.dart';
 export 'default_exception.dart';
 export 'not_found_exception.dart';
 export 'server_exception.dart';

--- a/lib/src/core/extensions/lucid_validator_extensions.dart
+++ b/lib/src/core/extensions/lucid_validator_extensions.dart
@@ -1,0 +1,17 @@
+import 'package:lucid_validation/lucid_validation.dart';
+import 'package:result_dart/result_dart.dart';
+
+import '../errors/errors.dart';
+
+extension LucidValidatorExtensions<T extends Object> on LucidValidator<T> {
+  Result<T, BaseException> validateResult(T object) {
+    final result = validate(object);
+    if (result.isValid) {
+      return Success(object);
+    }
+
+    return Failure(
+      CredentialsValidationException(message: result.exceptions.first.message),
+    );
+  }
+}

--- a/lib/src/core/typedefs/types.dart
+++ b/lib/src/core/typedefs/types.dart
@@ -1,5 +1,5 @@
-import 'package:fpdart/fpdart.dart';
+import 'package:result_dart/result_dart.dart';
 
 import '../errors/base_exception.dart';
 
-typedef Output<T> = Either<BaseException, T>;
+typedef Output<T extends Object> = Result<T, BaseException>;

--- a/lib/src/core/usecase/usecase_interface.dart
+++ b/lib/src/core/usecase/usecase_interface.dart
@@ -1,5 +1,5 @@
 import '../typedefs/types.dart';
 
-abstract interface class UseCase<Type, Params> {
+abstract interface class UseCase<Type extends Object, Params> {
   Future<Output<Type>> call(Params params);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -167,14 +167,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  fpdart:
-    dependency: "direct main"
-    description:
-      name: fpdart
-      sha256: "1b84ce64453974159f08046f5d05592020d1fcb2099d7fe6ec58da0e7337af77"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.1"
   gap:
     dependency: "direct main"
     description:
@@ -271,6 +263,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  lucid_validation:
+    dependency: "direct main"
+    description:
+      name: lucid_validation
+      sha256: "2741e7cb953cca8e03354e59ff7aa8ee093a16094e5a0de600b50340f534d8e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
@@ -383,6 +383,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  result_dart:
+    dependency: "direct main"
+    description:
+      name: result_dart
+      sha256: "3c69c864a08df0f413a86be211d07405e9a53cc1ac111e3cc8365845a0fb5288"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   flutter_bloc: ^8.1.6
   equatable: ^2.0.5
   go_router: ^14.4.1
-  fpdart: ^1.1.1
   gap: ^3.0.1
   flutter_masked_text2: ^0.9.1
   dio: ^5.7.0
@@ -25,6 +24,8 @@ dependencies:
   get_it: ^8.0.2
   bloc: ^8.1.4
   logger: ^2.5.0
+  lucid_validation: ^1.1.0
+  result_dart: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Uma proposta para implementação do Lucid Validation e do Result Dart

### Gif:

![Gravação de Tela 2024-11-24 às 18 36 42](https://github.com/user-attachments/assets/cf1cacd3-96b7-46ae-a71d-100e4f3b39c5)


### Principais mudanças no código: 

Validações dos parametros do usecase: 

```dart 
class LoginParamsValidator extends LucidValidator<LoginParams> {
  LoginParamsValidator() {
    ruleFor((user) => user.email, key: 'email', label: 'e-mail')
        .notEmpty()
        .validEmail();

    ruleFor((user) => user.password, key: 'password', label: 'senha') //
        .notEmpty()
        .minLength(8)
        .mustHaveLowercase()
        .mustHaveUppercase()
        .mustHaveNumber()
        .mustHaveSpecialCharacter();
  }
}
```

na `page` o código fica limpo e simples:

```dart
TextInputDs(
  label: 'senha',
  isPassword: true,
  onChanged: _loginParams.setPassword,
  validator: _validator.byField(_loginParams, 'password'),
  autovalidateMode: AutovalidateMode.onUserInteraction,
),
```

E com um `extension` e adicionando do `result_dart`podemos simplificar o código de emisão do estado executando funções em cascata e garantindo que o usecase será executado apenas se o `loginParams` estiver valido, caso contrario retorna um `CredentialsValidationException`

```dart
emit(LoginAuthLoading());

final validator = LoginParamsValidator();

final newState = await validator
    .validateResult(event.loginParams)                  /// valida o loginParams
    .toAsyncResult()                                    /// converte em um async Result: Future<Result<...>>
    .flatMap(_loginUsecase.call)                        /// executa o usecase
    .fold(LoginAuthSuccess.new, LoginAuthFailure.new);  /// converte para o estado apropriado
      
 emit(newState);
```
