### PR TITLE
Criar tela de filtros para adoção de pet

### DIFF
--- a/design_system/lib/design_system.dart
+++ b/design_system/lib/design_system.dart
@@ -6,4 +6,5 @@ export './src/drawer/drawer_ds.dart';
 export './src/icons/icons.dart';
 export './src/image/image.dart';
 export './src/inputs/inputs.dart';
+export './src/sliders/sliders.dart';
 export './src/theme/theme.dart';

--- a/design_system/lib/src/components/choose_pet_donation_type_row.dart
+++ b/design_system/lib/src/components/choose_pet_donation_type_row.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import '../../design_system.dart';
+import 'package:gap/gap.dart';
+
+class ChoosePetDonationTypeRow extends StatefulWidget {
+  const ChoosePetDonationTypeRow({
+    super.key,
+    required this.label,
+  });
+
+  final String label;
+
+  @override
+  State<ChoosePetDonationTypeRow> createState() =>
+      _ChoosePetDonationTypeRowState();
+}
+
+class _ChoosePetDonationTypeRowState extends State<ChoosePetDonationTypeRow> {
+  Map<String, bool> buttonStates = {
+    'temporario': true,
+    'permanente': false,
+  };
+
+  void toggleSelection(String selected) {
+    setState(() {
+      buttonStates.updateAll((key, value) => false);
+
+      buttonStates[selected] = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          widget.label,
+          style: theme.textTheme.titleSmall,
+        ),
+        const Gap(8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          child: Row(
+            children: [
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['temporario']!,
+                onPressed: () => toggleSelection('temporario'),
+                title: 'Temporário',
+              ),
+              const Gap(10),
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['permanente']!,
+                onPressed: () => toggleSelection('permanente'),
+                title: 'Permanente',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/design_system/lib/src/components/choose_pet_size_row.dart
+++ b/design_system/lib/src/components/choose_pet_size_row.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../../design_system.dart';
+import 'package:gap/gap.dart';
+
+class ChoosePetSizeRow extends StatefulWidget {
+  const ChoosePetSizeRow({
+    super.key,
+    required this.label,
+  });
+
+  final String label;
+
+  @override
+  State<ChoosePetSizeRow> createState() => _ChoosePetSizeRowState();
+}
+
+class _ChoosePetSizeRowState extends State<ChoosePetSizeRow> {
+  Map<String, bool> buttonStates = {
+    'pequeno': true,
+    'medio': false,
+    'grande': false,
+    'enorme': false,
+  };
+
+  void toggleSelection(String selected) {
+    setState(() {
+      buttonStates.updateAll((key, value) => false);
+
+      buttonStates[selected] = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          widget.label,
+          style: theme.textTheme.titleSmall,
+        ),
+        const Gap(8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          child: Row(
+            children: [
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['pequeno']!,
+                onPressed: () => toggleSelection('pequeno'),
+                title: 'Pequeno',
+              ),
+              const Gap(10),
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['medio']!,
+                onPressed: () => toggleSelection('medio'),
+                title: 'Médio',
+              ),
+              const Gap(10),
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['grande']!,
+                onPressed: () => toggleSelection('grande'),
+                title: 'Grande',
+              ),
+              const Gap(10),
+              SelectableButtonDs(
+                width: 100,
+                height: 30,
+                isSelected: buttonStates['enorme']!,
+                onPressed: () => toggleSelection('enorme'),
+                title: 'Enorme',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/design_system/lib/src/components/components.dart
+++ b/design_system/lib/src/components/components.dart
@@ -1,2 +1,4 @@
 export './choose_pet_type_row.dart';
 export './choose_pet_gender_row.dart';
+export './choose_pet_donation_type_row.dart';
+export './choose_pet_size_row.dart';

--- a/design_system/lib/src/sliders/age_slider.dart
+++ b/design_system/lib/src/sliders/age_slider.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../theme/theme.dart';
+
+class AgeSlider extends StatefulWidget {
+  const AgeSlider({super.key});
+
+  @override
+  _AgeSliderState createState() => _AgeSliderState();
+}
+
+class _AgeSliderState extends State<AgeSlider> {
+  double _currentValue = 6; // Valor inicial em meses
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        //! Label
+        Align(
+          alignment: Alignment.bottomLeft,
+          child: Text(
+            'Idade',
+            style: theme.textTheme.titleSmall,
+          ),
+        ),
+
+        const SizedBox(height: 10),
+        //! Slider
+        Column(
+          children: [
+            SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                activeTrackColor: Colors.grey[300],
+                inactiveTrackColor: Colors.grey[300],
+                thumbColor: AppColors.primaryColor,
+                overlayColor: AppColors.primaryColor.withOpacity(0.2),
+                thumbShape:
+                    const RoundSliderThumbShape(enabledThumbRadius: 12.0),
+                trackHeight: 8.0,
+              ),
+              child: Slider(
+                value: _currentValue,
+                min: 6,
+                max: 96, //?Equivale a 8 anos
+                divisions: 4,
+                onChanged: (value) {
+                  setState(() {
+                    _currentValue = value;
+                  });
+                },
+              ),
+            ),
+            //! Intervalo
+            Text(
+              _currentValue >= 96
+                  ? '(8 anos ou mais)' //
+                  : '(${_formatAge(_currentValue)} - ${_formatAgeRange(_currentValue)})',
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w400,
+                color: AppColors.textGreyColor,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('6 meses', style: theme.textTheme.bodySmall),
+            Text('2 anos', style: theme.textTheme.bodySmall),
+            Text('4 anos', style: theme.textTheme.bodySmall),
+            Text('6 anos', style: theme.textTheme.bodySmall),
+            Text('8 anos', style: theme.textTheme.bodySmall),
+          ],
+        ),
+      ],
+    );
+  }
+
+  //! Função para formatar o valor atual em meses ou anos
+  String _formatAge(double value) {
+    if (value < 12) {
+      return '${value.round()} meses';
+    } else {
+      return '${(value / 12).round()} anos';
+    }
+  }
+
+  //! Função para formatar o intervalo final
+  String _formatAgeRange(double value) {
+    if (value < 12) {
+      return '2 anos';
+    } else {
+      return '${(value / 12).round() + 2} anos';
+    }
+  }
+}

--- a/design_system/lib/src/sliders/sliders.dart
+++ b/design_system/lib/src/sliders/sliders.dart
@@ -1,0 +1,1 @@
+export './age_slider.dart';

--- a/design_system/lib/src/theme/app_colors.dart
+++ b/design_system/lib/src/theme/app_colors.dart
@@ -7,4 +7,5 @@ class AppColors {
   static const Color blackColor = Color(0xFF000000);
   static const Color blueColor = Color(0xff1c46dd);
   static const Color inputGrayColor = Color(0xffefeff1);
+  static const Color textGreyColor = Color(0xFF767676);
 }

--- a/lib/src/app/features/home/presentation/pages/filters_page.dart
+++ b/lib/src/app/features/home/presentation/pages/filters_page.dart
@@ -53,6 +53,16 @@ class FiltersPage extends StatelessWidget {
             const ChoosePetGenderRow(
               label: 'Qual o sexo?',
             ),
+            const Gap(24),
+            const ChoosePetDonationTypeRow(
+              label: 'Qual o tipo da doação?',
+            ),
+            const Gap(24),
+            const ChoosePetSizeRow(
+              label: 'E o tamanho?',
+            ),
+            const Gap(24),
+            AgeSlider(),
           ],
         ),
       ),


### PR DESCRIPTION
Este Pull Request implementa a tela de filtros para adoção de pets, conforme descrito na issue #13. A nova tela permite que os usuários visualizem:

- Filtro de pets por espécie (cachorro, gato, aves, coelho).
- Filtro de pets por gênero (macho, fêmea).
- Filtro de pets por tipo de adoção (temporária, permanente).
- Filtro de pets por tamanho (pequeno, médio, grande, enorme).
- Filtro de pets por faixa etária.

Closes #13