### PR TITLE
refactor: session service

### DIFF
--- a/lib/src/app/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/src/app/features/auth/domain/usecases/login_usecase.dart
@@ -1,4 +1,7 @@
+import 'dart:developer';
+
 import '../../../../../core/client_http/app_response.dart';
+import '../../../../../core/services/session_service.dart';
 import '../../../../../core/typedefs/types.dart';
 import '../../../../../core/usecase/usecase_interface.dart';
 import '../dtos/login_params.dart';
@@ -7,13 +10,25 @@ import '../repositories/auth_repository_interface.dart';
 
 class LoginUsecase implements UseCase<AppResponse<AuthEntity>, LoginParams> {
   final IAuthRepository _authRepository;
+  final SessionService _sessionService;
 
-  LoginUsecase({
-    required IAuthRepository authRepository,
-  }) : _authRepository = authRepository;
+  LoginUsecase(
+      {required IAuthRepository authRepository,
+      required SessionService sessionService})
+      : _authRepository = authRepository,
+        _sessionService = sessionService;
 
   @override
   Future<Output<AppResponse<AuthEntity>>> call(LoginParams params) async {
-    return _authRepository.login(params.email, params.password);
+    final result = await _authRepository.login(params.email, params.password);
+
+    final appResponse = result.getOrNull();
+
+    if (result.isSuccess() && appResponse != null) {
+      log('Token: ${appResponse.data!.accessToken}');
+      _sessionService.saveToken(appResponse.data!.accessToken);
+    }
+
+    return result;
   }
 }

--- a/lib/src/app/features/auth/presentation/pages/login_page.dart
+++ b/lib/src/app/features/auth/presentation/pages/login_page.dart
@@ -12,7 +12,6 @@ import '../../../../../core/utils/show_snack_bar.dart';
 import '../../domain/dtos/login_params.dart';
 import '../../domain/validators/login_params_validator.dart';
 import '../bloc/auth_bloc.dart';
-import '../controller/session_controller.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -32,7 +31,6 @@ class _LoginPageState extends State<LoginPage> {
     // final size = MediaQuery.sizeOf(context);
     final theme = Theme.of(context);
     final authBloc = GetIt.I.get<AuthBloc>();
-    final sessionController = GetIt.I.get<SessionController>();
 
     return Scaffold(
       appBar: AppBar(
@@ -74,8 +72,6 @@ class _LoginPageState extends State<LoginPage> {
                 BlocConsumer<AuthBloc, AuthState>(
                   listener: (context, state) {
                     if (state is LoginAuthSuccess) {
-                      log('Token: ${state.data.data!.accessToken}');
-                      sessionController.saveToken(state.data.data!.accessToken);
                       formKey.currentState!.reset();
                       showMessageSnackBar(
                         context,

--- a/lib/src/core/DI/dependency_injector.dart
+++ b/lib/src/core/DI/dependency_injector.dart
@@ -6,10 +6,10 @@ import '../../app/features/auth/domain/repositories/auth_repository_interface.da
 import '../../app/features/auth/domain/usecases/login_usecase.dart';
 import '../../app/features/auth/domain/usecases/sign_up_usecase.dart';
 import '../../app/features/auth/presentation/bloc/auth_bloc.dart';
-import '../../app/features/auth/presentation/controller/session_controller.dart';
 import '../cache/shared_preferences/shared_preferences_impl.dart';
 import '../client_http/dio/rest_client_dio_impl.dart';
 import '../logger/logger_app_logger_impl.dart';
+import '../services/session_service.dart';
 
 final injector = GetIt.instance;
 
@@ -21,9 +21,9 @@ void setupDependencyInjector() {
     ),
   );
 
-  //SESSION CONTROLLER
-  injector.registerFactory<SessionController>(
-    () => SessionController(
+  //SESSION Service
+  injector.registerFactory<SessionService>(
+    () => SessionService(
       sharedPreferences: SharedPreferencesImpl(),
     ),
   );
@@ -46,6 +46,7 @@ void setupDependencyInjector() {
       ),
       loginUsecase: LoginUsecase(
         authRepository: injector<IAuthRepository>(),
+        sessionService: injector<SessionService>(),
       ),
     ),
   );

--- a/lib/src/core/services/session_service.dart
+++ b/lib/src/core/services/session_service.dart
@@ -1,10 +1,10 @@
-import '../../../../../core/cache/cache_params.dart';
-import '../../../../../core/cache/shared_preferences/shared_preferences_impl.dart';
+import '../cache/cache.dart';
+import '../cache/shared_preferences/shared_preferences_impl.dart';
 
-class SessionController {
+class SessionService {
   final SharedPreferencesImpl _sharedPreferences;
 
-  SessionController({
+  SessionService({
     required SharedPreferencesImpl sharedPreferences,
   }) : _sharedPreferences = sharedPreferences;
 


### PR DESCRIPTION
## Esse refactor visa seguir os principios de SOLID

1. A tela de Login estava com a responsabilidade de salvar a sessão (isso era uma quebra de responsabilidade e um furo de camada, ja que "salvar sessão é um regra de login")
  - Foi movido para dentro do usecase de login

2. O "session controller" ficava dentro da presentation de auth, porem ele não esta associado a tela, é muitos será usado apenas pelo auth.
  - Foi movido para o core, com um nome de sessionservice.
  
  ### resultado: 
  
<img width="1052" alt="Captura de Tela 2024-11-27 às 21 33 33" src="https://github.com/user-attachments/assets/d83d5982-fb63-4797-b9a9-bc0baef30c34">
